### PR TITLE
added maxline parameter to Multicell function

### DIFF
--- a/src/tFPDF/PDF.php
+++ b/src/tFPDF/PDF.php
@@ -1434,7 +1434,7 @@ class PDF
      *
      * @return string
      */
-    public function MultiCell($flt_width, $flt_height, $str_text, $int_border = 0, $str_alignment = 'J', $bol_fill = false, $maxline = 0)
+    public function MultiCell($flt_width, $flt_height, $str_text, $int_border = 0, $str_alignment = 'J', $bol_fill = false, $int_maxline = 0)
     {
         // Output text with automatic or explicit line breaks
         $arr_character_width = &$this->arr_current_font_info['cw'];
@@ -1506,7 +1506,7 @@ class PDF
                 if ($int_border && $int_line_count == 2) {
                     $mix_adjusted_border = $mix_adjusted_border_2;
                 }
-                if($maxline && $int_line_count > $maxline) {
+                if($int_maxline && $int_line_count > $int_maxline) {
                     return substr($str_text, $int_i);
                 }
                 continue;
@@ -1559,8 +1559,8 @@ class PDF
                     $mix_adjusted_border = $mix_adjusted_border_2;
                 }
 
-                if($maxline && $int_line_count > $maxline) {
-                    if($this->int_word_spacing > 0) {
+                if ($int_maxline && $int_line_count > $int_maxline) {
+                    if ($this->int_word_spacing > 0) {
                         $this->int_word_spacing = 0;
                         $this->Out('0 Tw');
                     }

--- a/src/tFPDF/PDF.php
+++ b/src/tFPDF/PDF.php
@@ -1431,6 +1431,7 @@ class PDF
      * @param int $int_border
      * @param string $str_alignment
      * @param bool $bol_fill
+     * @param int int_maxline
      *
      * @return string
      */

--- a/src/tFPDF/PDF.php
+++ b/src/tFPDF/PDF.php
@@ -1431,8 +1431,10 @@ class PDF
      * @param int $int_border
      * @param string $str_alignment
      * @param bool $bol_fill
+     *
+     * @return string
      */
-    public function MultiCell($flt_width, $flt_height, $str_text, $int_border = 0, $str_alignment = 'J', $bol_fill = false)
+    public function MultiCell($flt_width, $flt_height, $str_text, $int_border = 0, $str_alignment = 'J', $bol_fill = false, $maxline = 0)
     {
         // Output text with automatic or explicit line breaks
         $arr_character_width = &$this->arr_current_font_info['cw'];
@@ -1504,6 +1506,9 @@ class PDF
                 if ($int_border && $int_line_count == 2) {
                     $mix_adjusted_border = $mix_adjusted_border_2;
                 }
+                if($maxline && $int_line_count > $maxline) {
+                    return substr($str_text, $int_i);
+                }
                 continue;
             }
             if ($str_character == ' ') {
@@ -1553,6 +1558,15 @@ class PDF
                 if ($int_border && $int_line_count == 2) {
                     $mix_adjusted_border = $mix_adjusted_border_2;
                 }
+
+                if($maxline && $int_line_count > $maxline) {
+                    if($this->int_word_spacing > 0) {
+                        $this->int_word_spacing = 0;
+                        $this->Out('0 Tw');
+                    }
+                    return substr($str_text, $int_i);
+                }
+
             } else {
                 $int_i++;
             }
@@ -1571,6 +1585,7 @@ class PDF
             $this->Cell($flt_width, $flt_height, substr($str_text, $int_j, $int_i - $int_j), $mix_adjusted_border, 2, $str_alignment, $bol_fill);
         }
         $this->flt_position_x = $this->int_left_margin;
+        return '';
     }
 
     /**


### PR DESCRIPTION
When calling Multicell function, if the number of lines (implicit or
explicit) reaches the limit specified by maxline parameter, the
function stops and returns the non-printed part.

If maxline equals 0, there will be no limitation of the number of lines.