### PR TITLE
Fix phpdocs

### DIFF
--- a/src/tFPDF/PDF.php
+++ b/src/tFPDF/PDF.php
@@ -1287,8 +1287,8 @@ class PDF
     }
 
     /**
-     * @param $flt_width
-     * @param int $flt_height
+     * @param float $flt_width
+     * @param float $flt_height
      * @param string $str_text
      * @param int $int_border
      * @param int $int_line_number
@@ -1589,8 +1589,8 @@ class PDF
     }
 
     /**
-     * @param $flt_height
-     * @param $str_text
+     * @param float $flt_height
+     * @param string $str_text
      * @param string $str_link
      */
     public function Write($flt_height, $str_text, $str_link = '')
@@ -1719,8 +1719,8 @@ class PDF
 
     /**
      * @param $str_file
-     * @param null $flt_x
-     * @param null $flt_y
+     * @param float|null $flt_x
+     * @param float|null $flt_y
      * @param int $int_width
      * @param int $int_height
      * @param string $str_type


### PR DESCRIPTION
Hello. In this PR I purpose three edits to the phpdoc of some methods.

## Cell
* Argument $flt_width now expects float
* Argument $flt_height now expects float

## Write
* Argument $flt_height now expects float, as it is passed to Cell.
* Argument $str_text now expects string.

## Image
* Arguments for x and y now expects float or null.

I assume the prefix "flt" of an argument means the value should be float, and not an integer. That is why I'm suggesting the edits to Cell and Write. My first issue was the null on Image as it clearly expects more than just null.