### PR TITLE
Using 0-255 grayscale scale

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v2.2.2]
+
+### Fixed
+- Using 0-255 grayscale scale, instead 0-100, which was changed since 2.2.0 
+
 ## [v2.2.1]
 
 ### Fixed
@@ -45,7 +50,8 @@ All notable changes to this project will be documented in this file.
 ### Fixes
 - "U" style did not actually underline the text.
 
-[Unreleased]: https://github.com/DocnetUK/tfpdf/compare/v2.2.1...HEAD
+[Unreleased]: https://github.com/DocnetUK/tfpdf/compare/v2.2.2...HEAD
+[v2.2.2]: https://github.com/DocnetUK/tfpdf/compare/v2.2.1...v2.2.2
 [v2.2.1]: https://github.com/DocnetUK/tfpdf/compare/v2.2.0...v2.2.1
 [v2.2.0]: https://github.com/DocnetUK/tfpdf/compare/v2.1.1...v2.2.0
 [v2.1.1]: https://github.com/DocnetUK/tfpdf/compare/v2.1.0...v2.1.1

--- a/src/tFPDF/PDF.php
+++ b/src/tFPDF/PDF.php
@@ -851,6 +851,27 @@ class PDF
     }
 
     /**
+     * @param array $args
+     * @return string
+     */
+    protected function getColourString($args)
+    {
+        if (count($args) && is_array($args[0])) {
+            $args = $args[0];
+        }
+        switch (count($args)) {
+            case 1:
+                return sprintf('%.3f g', $args[0] / 255);
+            case 3:
+                return sprintf('%.3f %.3f %.3f rg', $args[0] / 255, $args[1] / 255, $args[2] / 255);
+            case 4:
+                return sprintf('%.3f %.3f %.3f %.3f k', $args[0] / 100, $args[1] / 100, $args[2] / 100, $args[3] / 100);
+            default:
+                return '0 g';
+        }
+    }
+
+    /**
      * @param int $int_red
      * @param int|null $int_green
      * @param int|null $int_blue
@@ -859,22 +880,8 @@ class PDF
     {
         // Set color for all stroking operations
         $args = func_get_args();
-        if (count($args) and is_array($args[0])) {
-            $args = $args[0];
-        }
-        switch (count($args)) {
-            case 1:
-                $this->str_draw_color = sprintf('%.3f G', $args[0] / 100);
-                break;
-            case 3:
-                $this->str_draw_color = sprintf('%.3f %.3f %.3f RG', $args[0] / 255, $args[1] / 255, $args[2] / 255);
-                break;
-            case 4:
-                $this->str_draw_color = sprintf('%.3f %.3f %.3f %.3f K', $args[0] / 100, $args[1] / 100, $args[2] / 100, $args[3] / 100);
-                break;
-            default:
-                $this->str_draw_color = '0 G';
-        }
+        // Setting draw colour (unlike any other colours) requires it to be uppercase
+        $this->str_draw_color = strtoupper($this->getColourString($args));
         if ($this->int_page > 0) {
             $this->Out($this->str_draw_color);
         }
@@ -889,22 +896,7 @@ class PDF
     {
         // Set color for all filling operations
         $args = func_get_args();
-        if (count($args) and is_array($args[0])) {
-            $args = $args[0];
-        }
-        switch (count($args)) {
-            case 1:
-                $this->str_fill_color = sprintf('%.3f g', $args[0] / 100);
-                break;
-            case 3:
-                $this->str_fill_color = sprintf('%.3f %.3f %.3f rg', $args[0] / 255, $args[1] / 255, $args[2] / 255);
-                break;
-            case 4:
-                $this->str_fill_color = sprintf('%.3f %.3f %.3f %.3f k', $args[0] / 100, $args[1] / 100, $args[2] / 100, $args[3] / 100);
-                break;
-            default:
-                $this->str_fill_color = '0 g';
-        }
+        $this->str_fill_color = $this->getColourString($args);
         $this->bol_fill_text_differ = ($this->str_fill_color != $this->str_text_color);
         if ($this->int_page > 0) {
             $this->Out($this->str_fill_color);
@@ -920,22 +912,7 @@ class PDF
     {
         // Set color for text
         $args = func_get_args();
-        if (count($args) and is_array($args[0])) {
-            $args = $args[0];
-        }
-        switch (count($args)) {
-            case 1:
-                $this->str_text_color = sprintf('%.3f g', $args[0] / 100);
-                break;
-            case 3:
-                $this->str_text_color = sprintf('%.3f %.3f %.3f rg', $args[0] / 255, $args[1] / 255, $args[2] / 255);
-                break;
-            case 4:
-                $this->str_text_color = sprintf('%.3f %.3f %.3f %.3f k', $args[0] / 100, $args[1] / 100, $args[2] / 100, $args[3] / 100);
-                break;
-            default:
-                $this->str_text_color = '0 g';
-        }
+        $this->str_text_color = $this->getColourString($args);
         $this->bol_fill_text_differ = ($this->str_fill_color != $this->str_text_color);
     }
 

--- a/tests/PDFGeneratedTest.php
+++ b/tests/PDFGeneratedTest.php
@@ -27,7 +27,7 @@ class PDFGeneratedTest extends TestCase
         $pdfLibrary->SetTextColor(255, 0, 0);
         $pdfLibrary->Write(5, "Hello Red Courier World");
         $pdfLibrary->Ln(10);
-        $pdfLibrary->SetTextColor(50);
+        $pdfLibrary->SetTextColor(122.5);
         $pdfLibrary->Write(5, "Hello Gray Courier World");
         $pdfLibrary->SetFont('Courier', 'U', 14);
         $pdfLibrary->Ln(10);
@@ -35,6 +35,22 @@ class PDFGeneratedTest extends TestCase
         $pdfLibrary->Write(5, "Hello Underscored Courier World");
 
         $pdfLibrary->Ln(10);
+
+        // Set draw color example
+        $pdfLibrary->SetLineWidth(2);
+        $pdfLibrary->SetDrawColor(122.5);
+        $pdfLibrary->Line(20, $pdfLibrary->GetY(), 200, $pdfLibrary->GetY());
+        $pdfLibrary->Ln(10);
+
+        // Set fill color example
+        $pdfLibrary->SetFillColor(122.5);
+        $pdfLibrary->Rect(20, $pdfLibrary->GetY(), 180, 20, 'F');
+        $pdfLibrary->Ln(30);
+
+        // Set text color example
+        $pdfLibrary->SetFont('Courier', '', 14);
+        $pdfLibrary->SetTextColor(122.5);
+        $pdfLibrary->Text(20, $pdfLibrary->GetY(), 'Test text');
 
         $file = $pdfLibrary->output();
 


### PR DESCRIPTION
Instead 0-100, which was introduced (changed) in 2.2.0.

Also refactored copy&pasted parts of the code into a protected method.

I understand that 0-100 makes more sense, but overall I'd rather not change legacy behaviour if not necessary.