### PR TITLE
#28 remove pre-generated variable from *-font-metrics.php files

### DIFF
--- a/src/font/unifont/babelstonehan-bold-font-metrics.php
+++ b/src/font/unifont/babelstonehan-bold-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-72;
 $flt_underline_thickness=49;
 $ttffile='../font/unifont/BabelStoneHan-Bold.ttf';
 $originalsize=25281048;
-$fontkey='babelstonehanB';

--- a/src/font/unifont/babelstonehan-bolditalic-font-metrics.php
+++ b/src/font/unifont/babelstonehan-bolditalic-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-72;
 $flt_underline_thickness=49;
 $ttffile='../font/unifont/BabelStoneHan-BoldItalic.ttf';
 $originalsize=25281048;
-$fontkey='babelstonehanBI';

--- a/src/font/unifont/babelstonehan-font-metrics.php
+++ b/src/font/unifont/babelstonehan-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-72;
 $flt_underline_thickness=49;
 $ttffile='../font/unifont/BabelStoneHan.ttf';
 $originalsize=25281048;
-$fontkey='babelstonehan';

--- a/src/font/unifont/babelstonehan-italic-font-metrics.php
+++ b/src/font/unifont/babelstonehan-italic-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-72;
 $flt_underline_thickness=49;
 $ttffile='../font/unifont/BabelStoneHan-Italic.ttf';
 $originalsize=25281048;
-$fontkey='babelstonehanI';

--- a/src/font/unifont/dejavusans-bold-font-metrics.php
+++ b/src/font/unifont/dejavusans-bold-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSans-Bold.ttf';
 $originalsize=672300;
-$fontkey='dejavusansB';

--- a/src/font/unifont/dejavusans-boldoblique-font-metrics.php
+++ b/src/font/unifont/dejavusans-boldoblique-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSans-BoldOblique.ttf';
 $originalsize=611212;
-$fontkey='dejavusansBI';

--- a/src/font/unifont/dejavusans-extralight-font-metrics.php
+++ b/src/font/unifont/dejavusans-extralight-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSans-ExtraLight.ttf';
 $originalsize=345208;
-$fontkey='dejavusans';

--- a/src/font/unifont/dejavusans-font-metrics.php
+++ b/src/font/unifont/dejavusans-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSans.ttf';
 $originalsize=720012;
-$fontkey='dejavusans';

--- a/src/font/unifont/dejavusans-oblique-font-metrics.php
+++ b/src/font/unifont/dejavusans-oblique-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSans-Oblique.ttf';
 $originalsize=611556;
-$fontkey='dejavusansI';

--- a/src/font/unifont/dejavusanscondensed-bold-font-metrics.php
+++ b/src/font/unifont/dejavusanscondensed-bold-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansCondensed-Bold.ttf';
 $originalsize=631992;
-$fontkey='dejavusanscondensedB';

--- a/src/font/unifont/dejavusanscondensed-boldoblique-font-metrics.php
+++ b/src/font/unifont/dejavusanscondensed-boldoblique-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansCondensed-BoldOblique.ttf';
 $originalsize=580168;
-$fontkey='dejavusanscondensedBI';

--- a/src/font/unifont/dejavusanscondensed-font-metrics.php
+++ b/src/font/unifont/dejavusanscondensed-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansCondensed.ttf';
 $originalsize=643852;
-$fontkey='dejavusanscondensed';

--- a/src/font/unifont/dejavusanscondensed-oblique-font-metrics.php
+++ b/src/font/unifont/dejavusanscondensed-oblique-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansCondensed-Oblique.ttf';
 $originalsize=576004;
-$fontkey='dejavusanscondensedI';

--- a/src/font/unifont/dejavusansmono-bold-font-metrics.php
+++ b/src/font/unifont/dejavusansmono-bold-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansMono-Bold.ttf';
 $originalsize=313856;
-$fontkey='dejavusansmonoB';

--- a/src/font/unifont/dejavusansmono-boldoblique-font-metrics.php
+++ b/src/font/unifont/dejavusansmono-boldoblique-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansMono-BoldOblique.ttf';
 $originalsize=235848;
-$fontkey='dejavusansmonoBI';

--- a/src/font/unifont/dejavusansmono-font-metrics.php
+++ b/src/font/unifont/dejavusansmono-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansMono.ttf';
 $originalsize=333636;
-$fontkey='dejavusansmono';

--- a/src/font/unifont/dejavusansmono-oblique-font-metrics.php
+++ b/src/font/unifont/dejavusansmono-oblique-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSansMono-Oblique.ttf';
 $originalsize=241972;
-$fontkey='dejavusansmonoI';

--- a/src/font/unifont/dejavuserif-bold-font-metrics.php
+++ b/src/font/unifont/dejavuserif-bold-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerif-Bold.ttf';
 $originalsize=341072;
-$fontkey='dejavuserifB';

--- a/src/font/unifont/dejavuserif-bolditalic-font-metrics.php
+++ b/src/font/unifont/dejavuserif-bolditalic-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerif-BoldItalic.ttf';
 $originalsize=332036;
-$fontkey='dejavuserifBI';

--- a/src/font/unifont/dejavuserif-font-metrics.php
+++ b/src/font/unifont/dejavuserif-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerif.ttf';
 $originalsize=363200;
-$fontkey='dejavuserif';

--- a/src/font/unifont/dejavuserif-italic-font-metrics.php
+++ b/src/font/unifont/dejavuserif-italic-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerif-Italic.ttf';
 $originalsize=338776;
-$fontkey='dejavuserifI';

--- a/src/font/unifont/dejavuserifcondensed-bold-font-metrics.php
+++ b/src/font/unifont/dejavuserifcondensed-bold-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerifCondensed-Bold.ttf';
 $originalsize=316440;
-$fontkey='dejavuserifcondensedB';

--- a/src/font/unifont/dejavuserifcondensed-bolditalic-font-metrics.php
+++ b/src/font/unifont/dejavuserifcondensed-bolditalic-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerifCondensed-BoldItalic.ttf';
 $originalsize=331128;
-$fontkey='dejavuserifcondensedBI';

--- a/src/font/unifont/dejavuserifcondensed-font-metrics.php
+++ b/src/font/unifont/dejavuserifcondensed-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerifCondensed.ttf';
 $originalsize=330012;
-$fontkey='dejavuserifcondensed';

--- a/src/font/unifont/dejavuserifcondensed-italic-font-metrics.php
+++ b/src/font/unifont/dejavuserifcondensed-italic-font-metrics.php
@@ -15,4 +15,3 @@ $flt_underline_pos=-63;
 $flt_underline_thickness=44;
 $ttffile='../font/unifont/DejaVuSerifCondensed-Italic.ttf';
 $originalsize=338140;
-$fontkey='dejavuserifcondensedI';


### PR DESCRIPTION
These static pre-generated variable `$fontkey` rewrite custom name of '''font family''' specified in `AddFont()` method.