### PR TITLE
Fix PHP 8.2 compatibility for TTFontFile

### DIFF
--- a/src/tFPDF/TTFontFile.php
+++ b/src/tFPDF/TTFontFile.php
@@ -48,6 +48,7 @@ class TTFontFile
    private $charWidths;
    private $defaultWidth;
    private $maxStrLenRead;
+   private $TTCFonts;
 
    public function __construct()
    {


### PR DESCRIPTION
Fix `ErrorException: Creation of dynamic property tFPDF\TTFontFile::$TTCFonts is deprecated`