### PR TITLE
Fix PHP 8.2 Creation of dynamic property in TTFontFile.php

### DIFF
--- a/src/tFPDF/TTFontFile.php
+++ b/src/tFPDF/TTFontFile.php
@@ -49,6 +49,7 @@ class TTFontFile
    private $defaultWidth;
    private $maxStrLenRead;
    private $TTCFonts;
+   private $version;
 
    public function __construct()
    {


### PR DESCRIPTION
Fix a PHP 8.2 deprecation
```
Creation of dynamic property tFPDF\TTFontFile::$version is deprecated
```

Btw this field is unused, maybe we should remove it. Would you be open for a bigger refactor to add type hint and, follow PSR-12 conventions?